### PR TITLE
fix: soporte para múltiples roles en middleware de autorización

### DIFF
--- a/isc.time.report.be/isc.time.report.be.application/Utils/Auth/JWTUtils.cs
+++ b/isc.time.report.be/isc.time.report.be.application/Utils/Auth/JWTUtils.cs
@@ -1,4 +1,4 @@
-﻿using isc.time.report.be.domain.Entity.Auth;
+using isc.time.report.be.domain.Entity.Auth;
 using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
@@ -32,11 +32,13 @@ namespace isc.time.report.be.application.Utils.Auth
                 .Distinct()
                 .ToList();
 
-            var roleId = user.UserRole?
-                .FirstOrDefault(r => r.Status)?.RoleID;
+            var activeRoles = user.UserRole?.Where(r => r.Status).ToList();
 
-            if (roleId == null)
+            if (activeRoles == null || !activeRoles.Any())
                 throw new Exception("Usuario sin rol asignado");
+
+            var primaryRoleId = activeRoles.First().RoleID;
+            var allRoleIds = activeRoles.Select(r => r.RoleID.ToString()).ToList();
 
             var claims = new List<Claim>
     {
@@ -44,7 +46,8 @@ namespace isc.time.report.be.application.Utils.Auth
         new Claim("UserID", user.Id.ToString()),
         new Claim("EmployeeID", user.EmployeeID.ToString()),
         new Claim("PersonID", user.Employee?.PersonID.ToString() ?? "0"),
-        new Claim("RoleID", roleId.Value.ToString()),
+        new Claim("RoleID", primaryRoleId.ToString()),
+        new Claim("RoleIDs", string.Join(",", allRoleIds)),
         new Claim("modules", JsonSerializer.Serialize(normalizedModules))
     };
 

--- a/isc.time.report.be/isc.time.report.be/Security/ModuleAuthorizationMiddleware.cs
+++ b/isc.time.report.be/isc.time.report.be/Security/ModuleAuthorizationMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
 
@@ -49,25 +49,43 @@ namespace isc.time.report.be.api.Security
                 return;
             }
 
-            var roleId = user.FindFirst("RoleID")?.Value;
+            var roleIdsString = user.FindFirst("RoleIDs")?.Value;
+            var roleIds = new List<string>();
 
-            if (string.IsNullOrEmpty(roleId))
+            if (!string.IsNullOrEmpty(roleIdsString))
+            {
+                roleIds = roleIdsString.Split(',').ToList();
+            }
+            else
+            {
+                var singleRoleId = user.FindFirst("RoleID")?.Value;
+                if (!string.IsNullOrEmpty(singleRoleId))
+                    roleIds.Add(singleRoleId);
+            }
+
+            if (!roleIds.Any())
             {
                 await Deny(context, 403, "Token inválido (sin rol)");
                 return;
             }
 
-            // 🔹 NULL SAFE RoleModules
-            if (_options.RoleModules == null ||
-                !_options.RoleModules.TryGetValue(roleId, out var roleModules))
+            var hasGlobalWildcard = false;
+            if (_options.RoleModules != null)
             {
-                await Deny(context, 403, "Rol sin permisos");
-                return;
+                foreach (var rId in roleIds)
+                {
+                    if (_options.RoleModules.TryGetValue(rId, out var rModules) && rModules != null)
+                    {
+                        if (rModules.Contains("*"))
+                        {
+                            hasGlobalWildcard = true;
+                            break;
+                        }
+                    }
+                }
             }
 
-            roleModules ??= new List<string>();
-
-            if (roleModules.Contains("*"))
+            if (hasGlobalWildcard)
             {
                 await _next(context);
                 return;
@@ -81,30 +99,66 @@ namespace isc.time.report.be.api.Security
                 return;
             }
 
-            if (!roleModules.Contains(requiredModule))
-            {
-                await Deny(context, 403, $"Sin acceso al módulo {requiredModule}");
-                return;
-            }
-            if (IsOwnResourceEndpoint(context))
-            {
-                var selfOnlyRoles = _options.ResourceScope?.SelfOnlyRoles ?? new List<string>();
-                var fullAccessRoles = _options.ResourceScope?.FullAccessRoles ?? new List<string>();
+            var hasAccess = false;
+            var isOwnResourceEndpoint = IsOwnResourceEndpoint(context);
+            var selfOnlyRoles = _options.ResourceScope?.SelfOnlyRoles ?? new List<string>();
+            var fullAccessRoles = _options.ResourceScope?.FullAccessRoles ?? new List<string>();
+            var isAccessingOwnResource = false;
+            var hasModuleButNotResource = false;
 
-                if (fullAccessRoles.Contains(roleId))
+            if (isOwnResourceEndpoint)
+                isAccessingOwnResource = IsAccessingOwnResource(context);
+
+            foreach (var rId in roleIds)
+            {
+                if (_options.RoleModules != null && _options.RoleModules.TryGetValue(rId, out var rModules) && rModules != null)
                 {
-                    await _next(context);
+                    if (rModules.Contains(requiredModule))
+                    {
+                        if (isOwnResourceEndpoint)
+                        {
+                            if (fullAccessRoles.Contains(rId))
+                            {
+                                hasAccess = true;
+                                break;
+                            }
+                            else if (selfOnlyRoles.Contains(rId))
+                            {
+                                if (isAccessingOwnResource)
+                                {
+                                    hasAccess = true;
+                                    break;
+                                }
+                                else
+                                {
+                                    hasModuleButNotResource = true;
+                                }
+                            }
+                            else
+                            {
+                                hasAccess = true;
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            hasAccess = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (!hasAccess)
+            {
+                if (hasModuleButNotResource)
+                {
+                    await Deny(context, 403, "Solo puede acceder a su propio registro");
                     return;
                 }
 
-                if (selfOnlyRoles.Contains(roleId))
-                {
-                    if (!IsAccessingOwnResource(context))
-                    {
-                        await Deny(context, 403, "Solo puede acceder a su propio registro");
-                        return;
-                    }
-                }
+                await Deny(context, 403, $"Sin acceso al módulo {requiredModule}");
+                return;
             }
 
             await _next(context);


### PR DESCRIPTION
Se agregó el claim RoleIDs en el token JWT para almacenar todos los roles activos de un usuario al iniciar sesión. Adicionalmente, se actualizó ModuleAuthorizationMiddleware para evaluar todos los roles del usuario al verificar el acceso a un endpoint protegido en lugar de solo comprobar su rol principal, solucionando los errores HTTP 403 en usuarios multi-rol.